### PR TITLE
Emit incorrect count in completion toast

### DIFF
--- a/app/src/main/java/com/jorgecastillo/kanadrill/DrawActivity.java
+++ b/app/src/main/java/com/jorgecastillo/kanadrill/DrawActivity.java
@@ -19,6 +19,7 @@ public abstract class DrawActivity extends EveryActivity implements DialogInterf
 
     protected int count;
     protected int upto;
+    protected int incorrect;
 
     protected int[] order;
     private int[] buttonValues = new int[4];
@@ -27,7 +28,6 @@ public abstract class DrawActivity extends EveryActivity implements DialogInterf
     protected String[] meaning;
     protected String[] japanese;
     protected int[] sounds;
-    protected long startTime, tookyou;
 
     protected KanaAudioPlayer kanaAudioPlayer = null;
 
@@ -74,8 +74,6 @@ public abstract class DrawActivity extends EveryActivity implements DialogInterf
             default:
                 break;
         }
-
-        startTime = System.currentTimeMillis();
     }
 
     @Override
@@ -129,19 +127,9 @@ public abstract class DrawActivity extends EveryActivity implements DialogInterf
     private void setButtons() {
 
         if (count >= upto) {
-            tookyou = System.currentTimeMillis() - startTime;
-            String filename = "took_you";
-            String took_you = "" + (tookyou / 1000);
-            FileOutputStream outputStream;
-            Context mContext = getApplicationContext();
-            try {
-                outputStream = mContext.openFileOutput(filename, Context.MODE_PRIVATE);
-                outputStream.write(took_you.getBytes());
-                outputStream.close();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-            System.exit(0);
+            MainActivity.incorrect = incorrect;
+            finish();
+            return;
         }
 
         int[] used_values = new int[4];

--- a/app/src/main/java/com/jorgecastillo/kanadrill/DrillActivity.java
+++ b/app/src/main/java/com/jorgecastillo/kanadrill/DrillActivity.java
@@ -1,6 +1,5 @@
 package com.jorgecastillo.kanadrill;
 
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.res.Resources;
 import android.os.Bundle;
@@ -8,7 +7,6 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 
-import java.io.FileOutputStream;
 import java.util.Random;
 
 public abstract class DrillActivity extends EveryActivity implements DialogInterface.OnDismissListener{
@@ -18,6 +16,7 @@ public abstract class DrillActivity extends EveryActivity implements DialogInter
 
     protected int count;
     protected int upto;
+    protected int incorrect;
 
     protected int[] order;
     private int[] buttonValues = new int[4];
@@ -25,7 +24,6 @@ public abstract class DrillActivity extends EveryActivity implements DialogInter
 
     protected String[] meaning;
     protected String[] japanese;
-    protected long startTime, tookyou;
 
     protected Random random = new Random();
 
@@ -57,7 +55,6 @@ public abstract class DrillActivity extends EveryActivity implements DialogInter
             setButtons();
 
         }
-        startTime = System.currentTimeMillis();
     }
 
     public abstract void setArrays();
@@ -82,6 +79,7 @@ public abstract class DrillActivity extends EveryActivity implements DialogInter
             count++;
             setButtons();
         } else {
+            incorrect++;
             wrongKana(order[count]);
         }
     }
@@ -102,19 +100,9 @@ public abstract class DrillActivity extends EveryActivity implements DialogInter
     private void setButtons() {
 
         if (count >= upto) {
-            tookyou = System.currentTimeMillis() - startTime;
-            String filename = "took_you";
-            String took_you = "" + (tookyou / 1000);
-            FileOutputStream outputStream;
-            Context mContext = getApplicationContext();
-            try {
-                outputStream = mContext.openFileOutput(filename, Context.MODE_PRIVATE);
-                outputStream.write(took_you.getBytes());
-                outputStream.close();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-            System.exit(0);
+            MainActivity.incorrect = incorrect;
+            finish();
+            return;
         }
 
         int[] used_values = new int[4];

--- a/app/src/main/java/com/jorgecastillo/kanadrill/KanjiTrainingActivity.java
+++ b/app/src/main/java/com/jorgecastillo/kanadrill/KanjiTrainingActivity.java
@@ -84,7 +84,8 @@ public class KanjiTrainingActivity extends EveryActivity implements GoToDialog.C
       count = 830;
     }
     if (count >= upto) {
-      System.exit(0);
+      finish();
+      return;
     }
 
     setButtons();

--- a/app/src/main/java/com/jorgecastillo/kanadrill/MainActivity.java
+++ b/app/src/main/java/com/jorgecastillo/kanadrill/MainActivity.java
@@ -8,16 +8,14 @@ import android.preference.PreferenceManager;
 import android.view.View;
 import android.widget.Toast;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.util.Scanner;
-
 public class MainActivity extends EveryActivity {
 
     private SharedPreferences myPreferences;
     private Context myContext;
     private String textToast;
+
+    /** Global variable which activities set after completion. */
+    static int incorrect = -1;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -41,17 +39,9 @@ public class MainActivity extends EveryActivity {
 
         }
 
-        try {
-            FileInputStream input = openFileInput("took_you");
-            String took_you = new Scanner(input).useDelimiter("\\Z").next();
-            input.close();
-            Toast.makeText(getApplicationContext(), "It took you " + took_you + " seconds!", Toast.LENGTH_LONG)
-                    .show();
-            File mFile = new File(getFilesDir(), "took_you");
-            mFile.delete();
-        } catch (FileNotFoundException fnfe) {
-        } catch (Exception e) {
-            e.printStackTrace();
+        if (incorrect != -1) {
+            Toast.makeText(getApplicationContext(), incorrect + " incorrect", Toast.LENGTH_LONG).show();
+            incorrect = -1;
         }
     }
 

--- a/app/src/main/java/com/jorgecastillo/kanadrill/TrainingActivity.java
+++ b/app/src/main/java/com/jorgecastillo/kanadrill/TrainingActivity.java
@@ -72,7 +72,8 @@ public abstract class TrainingActivity extends EveryActivity {
 
     count++;
     if (count >= upto) {
-      System.exit(0);
+      finish();
+      return;
     }
     kanaText.setText(japanese[order[count]]);
     romanjiText.setText(meaning[order[count]]);


### PR DESCRIPTION
This is more useful than the duration.  Also prefer `finish` over
`System.exit` so that static variables do not reset.